### PR TITLE
Implement RECORD file parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+csv = "1.2.1"
 lazy_static = "1.4.0"
 pep440_rs = "0.3.6"
 regex = "1.8.1"
+serde = { version = "1.0.160", features = ["derive"] }
 thiserror = "1.0.40"
 zip = "0.6.4"
 
 [dev-dependencies]
+indoc = "2.0.1"
 pretty_assertions = "1.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use zip::ZipArchive;
 
 pub use metadata_file::MetadataFile;
-pub use record_file::RecordFile;
+pub use record_file::{RecordEntry, RecordFile};
 pub use wheel_file::WheelFile;
 pub use wheel_name::WheelName;
 

--- a/src/record_file.rs
+++ b/src/record_file.rs
@@ -1,15 +1,123 @@
+use serde::{Deserialize, Serialize};
+use std::io::{Cursor, Read};
+use std::ops::Deref;
 use std::str::FromStr;
 
-/// Used for parsing `... .dist-info/RECORD` files.
-pub struct RecordFile;
+/// Used for parsing `.dist-info/RECORD` files.
+///
+/// <https://www.python.org/dev/peps/pep-0376/#record>
+///
+/// Internally, this is a [Vec] of [RecordEntry].
+///
+/// # Example
+/// ```
+/// use std::str::FromStr;
+/// use pep_427::{RecordFile, RecordEntry};
+///
+/// let record = RecordFile::from_str(r#"
+/// tqdm/cli.py,sha256=x_c8nmc4Huc-lKEsAXj78ZiyqSJ9hJ71j7vltY67icw,10509
+/// tqdm-4.62.3.dist-info/RECORD,,
+/// "#).unwrap();
+/// assert_eq!(record.to_vec(), vec![
+///     RecordEntry {
+///         path: "tqdm/cli.py".to_string(),
+///         hash: Some("sha256=x_c8nmc4Huc-lKEsAXj78ZiyqSJ9hJ71j7vltY67icw".to_string()),
+///         size: Some(10509)
+///     },
+///     RecordEntry {
+///         path: "tqdm-4.62.3.dist-info/RECORD".to_string(),
+///         hash: None,
+///         size: None,
+///     },
+/// ]);
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RecordFile(Vec<RecordEntry>);
+
+impl RecordFile {
+    /// Read a `.dist-info/RECORD` file
+    pub fn read(record: &mut impl Read) -> Result<Self, RecordFileParseError> {
+        let entries: Vec<RecordEntry> = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .escape(Some(b'"'))
+            .from_reader(record)
+            .deserialize()
+            .map(|entry| {
+                let entry: RecordEntry = entry?;
+                Ok(RecordEntry {
+                    // selenium 4.1.0 uses absolute paths for some reason
+                    path: entry.path.trim_start_matches('/').to_string(),
+                    ..entry
+                })
+            })
+            .collect::<Result<_, RecordFileParseError>>()?;
+        Ok(Self(entries))
+    }
+}
 
 impl FromStr for RecordFile {
     type Err = RecordFileParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        todo!()
+        Self::read(&mut Cursor::new(s))
     }
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum RecordFileParseError {}
+impl Deref for RecordFile {
+    type Target = Vec<RecordEntry>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl IntoIterator for RecordFile {
+    type Item = RecordEntry;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// A line in a `.dist-info/RECORD` file
+#[derive(Debug, Clone, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
+pub struct RecordEntry {
+    pub path: String,
+    pub hash: Option<String>,
+    pub size: Option<usize>,
+}
+
+pub type RecordFileParseError = csv::Error;
+
+#[cfg(test)]
+mod test {
+    use crate::RecordFile;
+    use indoc::indoc;
+    use std::str::FromStr;
+
+    #[test]
+    fn record_with_absolute_paths() {
+        let record: &str = indoc! {"
+            /selenium/__init__.py,sha256=l8nEsTP4D2dZVula_p4ZuCe8AGnxOq7MxMeAWNvR0Qc,811
+            /selenium/common/exceptions.py,sha256=oZx2PS-g1gYLqJA_oqzE4Rq4ngplqlwwRBZDofiqni0,9309
+            selenium-4.1.0.dist-info/METADATA,sha256=jqvBEwtJJ2zh6CljTfTXmpF1aiFs-gvOVikxGbVyX40,6468
+            selenium-4.1.0.dist-info/RECORD,,
+        "};
+
+        let entries = RecordFile::from_str(record).unwrap();
+        let expected = [
+            "selenium/__init__.py",
+            "selenium/common/exceptions.py",
+            "selenium-4.1.0.dist-info/METADATA",
+            "selenium-4.1.0.dist-info/RECORD",
+        ]
+        .map(ToString::to_string)
+        .to_vec();
+        let actual = entries
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect::<Vec<String>>();
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
Hi! I've implemented a lot of similar wheel parsing functionality in [install-wheel-rs](https://github.com/konstin/poc-monotrail/tree/main/install-wheel-rs), e.g. [wheel filename parsing](https://github.com/konstin/poc-monotrail/blob/c3f9329258e7522bc916f083d374cf2c0c4afdc4/install-wheel-rs/src/wheel_tags.rs#L15-L51), so i thought i'd upstream my RECORD file parser into a more broadly usable crate.

I haven't implemented hash parsing, the user currently gets the whole `sha256=<base64>` as-is.